### PR TITLE
Add automated release scripts

### DIFF
--- a/cut-release.sh
+++ b/cut-release.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Print colored messages
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    error "Not in a git repository"
+    exit 1
+fi
+
+# Check if we're on main branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    error "Not on main branch (current: $CURRENT_BRANCH)"
+    read -p "Do you want to switch to main? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        git checkout main
+    else
+        exit 1
+    fi
+fi
+
+info "Pulling latest changes from origin/main..."
+git pull origin main
+
+# Check for uncommitted changes
+if ! git diff-index --quiet HEAD --; then
+    error "You have uncommitted changes. Please commit or stash them first."
+    git status --short
+    exit 1
+fi
+
+# Verify required files exist
+info "Checking required release files..."
+REQUIRED_FILES=("resources/diffsense.sh" "resources/Diffsense.shortcut")
+for file in "${REQUIRED_FILES[@]}"; do
+    if [ ! -f "$file" ]; then
+        error "Required file missing: $file"
+        exit 1
+    fi
+    info "✓ Found: $file"
+done
+
+# Capture short SHA
+SHORT_SHA=$(git rev-parse --short HEAD)
+TAG_NAME="diffsense@${SHORT_SHA}"
+
+info "Release tag will be: ${TAG_NAME}"
+echo
+
+# Confirm before proceeding
+warn "This will create and push tag: ${TAG_NAME}"
+warn "This will trigger the GitHub Actions release workflow"
+read -p "Continue? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    info "Release cancelled"
+    exit 0
+fi
+
+# Create annotated tag
+info "Creating annotated tag..."
+if git tag -a "${TAG_NAME}" -m "Release diffsense @ ${SHORT_SHA}"; then
+    info "✓ Tag created: ${TAG_NAME}"
+else
+    error "Failed to create tag"
+    exit 1
+fi
+
+# Push tag to trigger release
+info "Pushing tag to origin..."
+if git push origin "${TAG_NAME}"; then
+    info "✓ Tag pushed successfully"
+    echo
+    info "GitHub Actions will now create the release automatically"
+    info "Check status at: https://github.com/edgeleap/diffsense/actions"
+    info "Release will appear at: https://github.com/edgeleap/diffsense/releases/tag/${TAG_NAME}"
+else
+    error "Failed to push tag"
+    warn "Rolling back local tag..."
+    git tag -d "${TAG_NAME}"
+    exit 1
+fi

--- a/rollback-release.sh
+++ b/rollback-release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Check if tag name provided
+if [ $# -eq 0 ]; then
+    error "Usage: $0 <tag-name>"
+    error "Example: $0 diffsense@a1b2c3d"
+    exit 1
+fi
+
+TAG_NAME="$1"
+
+# Verify tag exists locally
+if ! git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+    error "Tag '$TAG_NAME' does not exist locally"
+    exit 1
+fi
+
+warn "This will delete tag: ${TAG_NAME}"
+warn "Both locally and remotely"
+read -p "Continue? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    info "Rollback cancelled"
+    exit 0
+fi
+
+# Delete local tag
+info "Deleting local tag..."
+git tag -d "$TAG_NAME"
+
+# Delete remote tag
+info "Deleting remote tag..."
+if git push origin --delete "$TAG_NAME"; then
+    info "✓ Tag deleted successfully"
+    info "The GitHub release will be automatically removed"
+else
+    warn "Failed to delete remote tag (it may not exist remotely)"
+fi


### PR DESCRIPTION
## Summary
Adds bash scripts to automate the release process as requested in #39.

## Changes
- ➕ `cut-release.sh`: Main script to automate tag creation and push
- ➕ `rollback-release.sh`: Utility script for rolling back releases

## Features
- **Safety checks**: Validates git repository state, branch, uncommitted changes, and required files
- **Interactive prompts**: Asks for confirmation before performing destructive operations
- **Colored output**: Clear visual feedback with info, warning, and error messages
- **Error handling**: Uses `set -euo pipefail` for robust error handling
- **Auto-rollback**: Cleans up local tag if remote push fails
- **Helpful links**: Provides URLs to GitHub Actions and release pages

## Usage

### Create a release
```bash
chmod +x cut-release.sh
./cut-release.sh
```

### Rollback a release
```bash
chmod +x rollback-release.sh
./rollback-release.sh diffsense@a1b2c3d
```

## Testing
The scripts have been tested for:
- ✅ Git repository validation
- ✅ Branch checking and switching
- ✅ Uncommitted changes detection
- ✅ Required files verification
- ✅ Tag creation and push
- ✅ Error handling and rollback

Fixes #39