### PR TITLE
Added cstm_cmt_msg_rules.md and modified resources/diffsense.sh.

### DIFF
--- a/cstm_cmt_msg_rules.md
+++ b/cstm_cmt_msg_rules.md
@@ -1,0 +1,46 @@
+# Custom Commit Message Rules
+
+## Format
+- Subject line: imperative verb + what changed (50 chars max)
+- Body: explain WHY, not what (the diff shows what)
+- Use present tense: "Add feature" not "Added feature"
+
+## Structure
+First line: <type>: <subject>
+
+Body (if needed):
+- Context: Why was this change necessary?
+- Impact: What does this enable or fix?
+- Notes: Any caveats, side effects, or follow-up needed
+
+## Type Prefixes
+Use one of these tags:
+- feat: New feature or capability
+- fix: Bug fix or correction
+- refactor: Code restructuring without behavior change
+- perf: Performance improvement
+- docs: Documentation only
+- test: Test additions or updates
+- chore: Build, tooling, dependencies
+- style: Formatting, whitespace, naming
+
+## Content Guidelines
+- Be specific: "Fix null pointer in user login" not "Fix bug"
+- Mention affected area: "auth:", "ui:", "api:", etc. when relevant
+- Avoid obvious statements: don't say "update file X" if that's clear from diff
+- Include ticket/issue reference if applicable: "Fixes #123"
+
+## Examples
+Good:
+- feat(auth): Add OAuth2 token refresh logic
+- fix(api): Prevent race condition in cache writes
+- refactor(db): Extract query builder to separate module
+
+Bad:
+- Updated files
+- Changes
+- Fixed stuff
+- WIP
+
+## Output Format
+Plain text only. No markdown formatting (**bold**, `code`, etc.)


### PR DESCRIPTION
Relates to: https://github.com/edgeleap/diffsense/pull/47

Changes:

- Bring your own prompt support (--byo), compatible with all previous modes.
- byo feature can handle all the relative, absolute and other file paths.
- Falls back to base prompt in case the file is not found, not readable or any other errors.
- Proper error handling with correct message corelation displayed in terminal.
- Added cstm_cmt_msg_rules.md file
- As mentioned in [PR](https://github.com/edgeleap/diffsense/pull/47) we don't support --byo "<filename>", --byo=<filename> is supported to make things simpler.

The byo feature is compatible with previous version of CLI commands. Example:

1. diffsense --byo=.commitFile.md
2. diffsense --byo=.commitFile.md --verbose
3. diffsense --byo=.commitFile.md --verbose --gpt
4. diffsense --byo=.commitFile.md --verbose --nopopup
5. diffsense --byo=.commitFile.md --verbose --gpt --nopopup [X this is not supported as --nopopup does not have the option to select the model as in our previous cases. Will include this in V2 if needed.]

cc: @eonist 